### PR TITLE
Make compatible w/ nodejs 10.2 & mongo 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Read the whole thesis:
 2. Start `mongod`
 3. Start OpenResty with the provided config: `openresty -c /absolute/path/to/openresty.conf`
 4. Have a look at `config.js` and see whether the settings match your setup.
-5. If you have made any changes: `npm install` and `npm compile`.
+5. If you have made any changes: `npm install` and `npm build`.
 6. Finally: `npm start`
 7. Point your web browser to `http://localhost:3000`, map an existing legacy Web API through the GUI and click the "Save API" button.
 8. Point your HAL-browser to `http://localhost:3000/api/` to access the legacy API as if it were a HAL Hypermedia API.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "httpinvoke": "^1.3.0",
     "jsonld": "^0.2.13",
     "jspath": "^0.2.12",
-    "mongojs": "^0.13.0",
+    "mongojs": "~2.5.0",
     "q": "^1.0.1",
     "silk-api-client": "^2.0.0",
     "underscore": "^1.6.0",

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ var config = require('./config');
 var silkExport = require('./silkExport');
 
 var app = express();
-var db = mongojs.connect("apis", ["apis"]);
+var db = mongojs("apis", ["apis"]);
 
 app.use( bodyParser.json() );
 app.set('json spaces', 4); //prettify json


### PR DESCRIPTION
Updated some dependencies and the mongoJS Library to make it "runnable" again.
There is still a mapping issue when you try to save APIs - but the basic functionality of browsing & crawling works again. 
Tested with:
- nodejs 10.2.1
- mongoDB 3.6.5
- OpenResty 1.13.6.2 